### PR TITLE
Added mf_read_problem for C and FFI

### DIFF
--- a/mf.cpp
+++ b/mf.cpp
@@ -4267,6 +4267,11 @@ mf_double mf_cross_validation_on_disk(
     return validator.do_cross_validation();
 }
 
+mf_problem mf_read_problem(char const *path)
+{
+    return read_problem(path);
+}
+
 mf_problem read_problem(string path)
 {
     mf_problem prob;

--- a/mf.def
+++ b/mf.def
@@ -19,3 +19,4 @@ EXPORTS
     calc_accuracy    @17
     calc_mpr    @18
     calc_auc    @19
+    mf_read_problem    @20

--- a/mf.h
+++ b/mf.h
@@ -71,8 +71,6 @@ struct mf_model
 
 mf_problem read_problem(std::string path);
 
-mf_problem mf_read_problem(char const *path);
-
 mf_int mf_save_model(struct mf_model const *model, char const *path);
 
 struct mf_model* mf_load_model(char const *path);
@@ -122,6 +120,8 @@ mf_double calc_accuracy(mf_problem *prob, mf_model *model);
 mf_double calc_mpr(mf_problem *prob, mf_model *model, bool transpose);
 
 mf_double calc_auc(mf_problem *prob, mf_model *model, bool transpose);
+
+mf_problem mf_read_problem(char const *path);
 
 #ifdef __cplusplus
 } // namespace mf

--- a/mf.h
+++ b/mf.h
@@ -71,6 +71,8 @@ struct mf_model
 
 mf_problem read_problem(std::string path);
 
+mf_problem mf_read_problem(char const *path);
+
 mf_int mf_save_model(struct mf_model const *model, char const *path);
 
 struct mf_model* mf_load_model(char const *path);


### PR DESCRIPTION
Currently, `read_problem` takes a `std::string` argument, which doesn't work with C or FFI. This PR adds a new `mf_read_problem` function (for backward compatibility) that takes a `char` string.