### PR TITLE
Use AVX and SSE by default when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ language: cpp
 matrix:
     include:
         - os: linux
-          env: DFLAG="-DUSESSE -DUSEOMP"
+          env: DFLAG="-DUSEOMP" OPTFLAG="-msse"
         - os: linux
-          env: DFLAG="-DUSEAVX -DUSEOMP"
+          env: DFLAG="-DUSEOMP" OPTFLAG="-mavx"
         - os: linux
-          env: DFLAG="-DUSESSE -DUSEOMP"
-        - os: linux
-          env: DFLAG="-DUSEOMP"
+          env: DFLAG="-DUSEOMP" OPTFLAG="-mno-sse"
         - os: linux
           env: DFLAG="-Wl,--no-as-needed"
         - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
         - os: linux
           env: DFLAG="-DUSEOMP" OPTFLAG="-mavx"
         - os: linux
-          env: DFLAG="-DUSEOMP" OPTFLAG="-mno-sse"
+          env: DFLAG="-DUSEOMP" OPTFLAG="-DNOSSE"
         - os: linux
           env: DFLAG="-Wl,--no-as-needed"
         - os: osx

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,10 @@
 CXX = g++
-CXXFLAGS = -Wall -O3 -pthread -std=c++0x -march=native
+OPTFLAG := -march=native
+CXXFLAGS = -Wall -O3 -pthread -std=c++0x $(OPTFLAG)
 OMPFLAG = -fopenmp
 SHVER = 2
 
 # run `make clean all' if you change the following flags.
-
-# comment the following flag if you want to disable SSE or enable AVX
-DFLAG = -DUSESSE
-
-# uncomment the following flags if you want to use AVX
-#DFLAG = -DUSEAVX
-#CXXFLAGS += -mavx
 
 # uncomment the following flags if you do not want to use OpenMP
 DFLAG += -DUSEOMP

--- a/README
+++ b/README
@@ -541,22 +541,7 @@ Functions available in LIBMF include:
 SSE, AVX, and OpenMP
 ====================
 
-LIBMF utilizes SSE instructions to accelerate the computation. If you cannot
-use SSE on your platform, then please comment out
-
-    DFLAG = -DUSESSE
-
-in Makefile to disable SSE.
-
-Some modern CPUs support AVX, which is more powerful than SSE. To enable AVX,
-please comment out
-
-    DFLAG = -DUSESSE
-
-and uncomment the following lines in Makefile.
-
-    DFLAG = -DUSEAVX
-    CFLAGS += -mavx
+LIBMF utilizes AVX and SSE instructions when available on your platform.
 
 If OpenMP is not available on your platform, please comment out the following
 lines in Makefile.

--- a/mf.cpp
+++ b/mf.cpp
@@ -19,6 +19,12 @@
 
 #include "mf.h"
 
+#if defined __AVX__ && !defined USESSE
+#define USEAVX 1
+#elif defined __SSE__
+#define USESSE 1
+#endif
+
 #if defined USESSE
 #include <pmmintrin.h>
 #endif

--- a/mf.cpp
+++ b/mf.cpp
@@ -21,7 +21,7 @@
 
 #if defined __AVX__ && !defined USESSE
 #define USEAVX 1
-#elif defined __SSE__
+#elif defined __SSE__ && !defined NOSSE
 #define USESSE 1
 #endif
 


### PR DESCRIPTION
This PR allows LIBMF to automatically detect AVX and SSE.

Modern compilers define `__AVX__` and `__SSE__` based on `-m` flags (like `-march`).

https://stackoverflow.com/questions/28939652/how-to-detect-sse-sse2-avx-avx2-avx-512-avx-128-fma-kcvi-availability-at-compile