### PR TITLE
Added random number generator to shuffling of values

### DIFF
--- a/mf.cpp
+++ b/mf.cpp
@@ -1114,11 +1114,11 @@ mf_model* Utility::init_model(mf_int m, mf_int n, mf_int k)
 
 vector<mf_int> Utility::gen_random_map(mf_int size)
 {
-    srand(0);
+    default_random_engine generator;
     vector<mf_int> map(size, 0);
     for(mf_int i = 0; i < size; ++i)
         map[i] = i;
-    random_shuffle(map.begin(), map.end());
+    shuffle(map.begin(), map.end(), generator);
     return map;
 }
 
@@ -4070,10 +4070,10 @@ CrossValidatorBase::CrossValidatorBase(mf_parameter param_, mf_int nr_folds_)
 mf_double CrossValidatorBase::do_cross_validation()
 {
     vector<mf_int> cv_blocks;
-    srand(0);
+    default_random_engine generator;
     for(mf_int block = 0; block < nr_bins*nr_bins; ++block)
         cv_blocks.push_back(block);
-    random_shuffle(cv_blocks.begin(), cv_blocks.end());
+    shuffle(cv_blocks.begin(), cv_blocks.end(), generator);
 
     if(!quiet)
     {


### PR DESCRIPTION
This PR adds a random number generator to the shuffling of values in the random map generation process. This PR also uses `void shuffle(_RanIt _First, _RanIt _Last, _Urng&& _Func)` instead of `void random_shuffle(_RanIt _First, _RanIt _Last)` to be able to use the RNG.

The function `void random_shuffle(_RanIt _First, _RanIt _Last)` is implemented differently on different platforms. I found this problem while working on ML .NET, where one of our matrix factorization unit tests produced varying results when run consecutively on MacOS. This variance led to these functions, where the seed variable of `rand()` is set through a `srand(0)`:

 https://github.com/cjlin1/libmf/blob/e70b9a32f7df32cce961bbbb997da074759a16fe/mf.cpp#L1115-L1123
https://github.com/cjlin1/libmf/blob/e70b9a32f7df32cce961bbbb997da074759a16fe/mf.cpp#L4070-L4123

This `srand(0)` command with `void random_shuffle(_RanIt _First, _RanIt _Last)` does not seem to be produce reliable consecutive results on MacOS. By using `void shuffle(_RanIt _First, _RanIt _Last, _Urng&& _Func)` and providing an appropriate random number generator, consistent results can be obtained on varying builds.