### PR TITLE
Made size of type unsigned long to fix signed/unsigned mismatch

### DIFF
--- a/mf.cpp
+++ b/mf.cpp
@@ -976,7 +976,7 @@ void Utility::grid_shuffle_scale_problem_on_disk(
 mf_float* Utility::malloc_aligned_float(mf_long size)
 {
     // Check if conversion from mf_long to size_t causes overflow.
-    if (size > numeric_limits<std::size_t>::max() / sizeof(mf_float) + 1)
+    if ((unsigned long)size > numeric_limits<std::size_t>::max() / sizeof(mf_float) + 1)
         throw bad_alloc();
     // [REVIEW] I hope one day we can use C11 aligned_alloc to replace
     // platform-depedent functions below. Both of Windows and OSX currently

--- a/mf.cpp
+++ b/mf.cpp
@@ -976,7 +976,8 @@ void Utility::grid_shuffle_scale_problem_on_disk(
 mf_float* Utility::malloc_aligned_float(mf_long size)
 {
     // Check if conversion from mf_long to size_t causes overflow.
-    if ((unsigned long)size > numeric_limits<std::size_t>::max() / sizeof(mf_float) + 1)
+    if (size >= 0 && sizeof(unsigned long) >= sizeof(mf_long) &&
+        (unsigned long)size > numeric_limits<std::size_t>::max() / sizeof(mf_float) + 1)
         throw bad_alloc();
     // [REVIEW] I hope one day we can use C11 aligned_alloc to replace
     // platform-depedent functions below. Both of Windows and OSX currently


### PR DESCRIPTION
This PR casts the `mf_long size` variable to type `unsigned long` to match the `unsigned long` type of `numeric_limits<std::size_t>::max() / sizeof(mf_float) + 1`. This is due to the warning I'm receiving which results in a build error in ML .NET where signed and unsigned longs are being compared:

> C:\Users\...\Documents\GitHub\machinelearning\src\Native\MatrixFactorizationNative\libmf\mf.cpp(979,14): warning C4018: '>': signed/unsigned mismatch [C:\Users\...\Documents\GitHub\machinelearning\bin\obj\x64.Debug\Native\MatrixFactorizationNative\MatrixFactorizationNative.vcxproj] [C:\Users\...\Documents\GitHub\machinelearning\src\Native\build.proj]