### PR TITLE
Fix memory leak in `ccd_one_class`

### DIFF
--- a/mf.cpp
+++ b/mf.cpp
@@ -3870,7 +3870,7 @@ try
         // The original data is reused as row-major one so
         // one duplicate for column-major one would be created.
         tr_csr = shared_ptr<mf_problem>(Utility::copy_problem(tr_, false));
-        tr_csc = shared_ptr<mf_problem>(Utility::copy_problem(tr_, true));
+        tr_csc = shared_ptr<mf_problem>(Utility::copy_problem(tr_, true), deleter());
         va = shared_ptr<mf_problem>(Utility::copy_problem(va_, false));
     }
 


### PR DESCRIPTION
This PR fixes a memory leak in `ccd_one_class` when `copy_data` is false.

Found with Valgrind.